### PR TITLE
Fix slow first response after reboot

### DIFF
--- a/linux_bot.service
+++ b/linux_bot.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Linux Bot
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart=/your/path/to/linux_bot/venv/bin/python /your/path/to/linux_bot/linux_bot.py

--- a/linux_bot/main.py
+++ b/linux_bot/main.py
@@ -10,6 +10,7 @@ from glob import glob
 import html
 import textwrap
 import json
+import threading
 
 # ENV VARIABLES
 # Load environment variables from .env
@@ -1104,6 +1105,49 @@ def handle_all_other_messages(message):
     logging.info("I'm sorry, I don't understand that command.")
     logging.debug(f"Handle_all_other_messages function ended.\n\n")
 
+def warmup():
+    """Pre-warm Docker, systemd, and Telegram API so the first user interaction is fast."""
+    logging.info("Starting warmup...")
+
+    def warmup_docker():
+        try:
+            subprocess.run('docker ps -a --format {{.Names}}', shell=True,
+                           capture_output=True, text=True, timeout=120)
+            logging.info("Docker warmup complete.")
+        except Exception as e:
+            logging.warning(f"Docker warmup failed: {e}")
+
+    def warmup_systemctl():
+        try:
+            subprocess.run('systemctl list-units --type=service --no-pager -q',
+                           shell=True, capture_output=True, text=True, timeout=30)
+            logging.info("Systemctl warmup complete.")
+        except Exception as e:
+            logging.warning(f"Systemctl warmup failed: {e}")
+
+    def warmup_telegram():
+        try:
+            bot.get_me()
+            logging.info("Telegram API warmup complete.")
+        except Exception as e:
+            logging.warning(f"Telegram API warmup failed: {e}")
+
+    threads = [
+        threading.Thread(target=warmup_docker, daemon=True),
+        threading.Thread(target=warmup_systemctl, daemon=True),
+        threading.Thread(target=warmup_telegram, daemon=True),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=120)
+
+    logging.info("Warmup complete.")
+
+
+print("Bot starting up...")
+logging.info("Bot starting up...")
+warmup()
 print("Bot running...")
 logging.info("Bot running...")
 bot.polling()

--- a/linux_monitoring.service
+++ b/linux_monitoring.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Linux Monitoring
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart=/your/path/to/linux_monitoring/venv/bin/python /your/path/to/linux_monitoring/monitoring.py

--- a/linux_monitoring/main.py
+++ b/linux_monitoring/main.py
@@ -316,6 +316,10 @@ def job():
     logging.info("Monitoring finished. See you in 5 minutes.")
 
 
+# Wait for system to fully boot before first monitoring run,
+# so it doesn't overload the system and slow down the bot.
+logging.info("Waiting 2 minutes for system to fully boot before first monitoring check...")
+time.sleep(120)
 job()
 
 # Schedule the job to run at the specified intervals (5 minute intervals, 00:00, 00:05 etc.)


### PR DESCRIPTION
Three changes to eliminate the ~1 minute delay on first interaction:

1. Bot warmup: pre-warm Docker daemon, systemd, and Telegram API
   connection in parallel threads before polling starts
2. Monitoring delay: wait 2 minutes before first monitoring run so it
   doesn't overload the system right after boot
3. Systemd services: use network-online.target instead of network.target
   to ensure network/DNS is actually ready before starting

https://claude.ai/code/session_0143cdRPKbZtr5Tf8xdRkwAe