### PR TITLE
Add system package update feature (apt + rkhunter)

### DIFF
--- a/agent/ENDPOINTS.md
+++ b/agent/ENDPOINTS.md
@@ -471,6 +471,28 @@ Error when script not configured:
 
 ---
 
+## System Updates
+
+Runs `apt-get update && apt-get upgrade -y` on the host. If rkhunter is installed, `rkhunter --propupd` is run automatically after a successful upgrade.
+
+### `POST /api/system-updates/dry-run`
+
+Run `apt-get update` and list upgradable packages without installing.
+
+```json
+{"success": true, "output": "Reading package lists...\nListing... Done\nnginx/stable 1.26.0-1 amd64 [upgradable from: 1.25.4-1]"}
+```
+
+### `POST /api/system-updates/run`
+
+Execute the full system update.
+
+```json
+{"success": true, "output": "Reading package lists...\n...\n--- rkhunter --propupd ---\n[ Rootkit Hunter version 1.4.6 ]\nFile updated: ..."}
+```
+
+---
+
 ## Backups
 
 Requires `scripts.backup` to be configured in config.yaml (path to [backup.sh](https://github.com/Made-By-Adem/linux-server-management-scripts)).

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -22,6 +22,7 @@ features:
   security_overview: true
   backups: true
   container_updates: true
+  system_updates: true
   logs: true
   server_ping: true
   system_info: true

--- a/src/linux_server_bot/api/routes.py
+++ b/src/linux_server_bot/api/routes.py
@@ -28,6 +28,7 @@ from linux_server_bot.shared.actions import (
     servers,
     services,
     sysinfo,
+    system_updates,
     updates,
     wol,
 )
@@ -351,6 +352,21 @@ async def updates_rollback():
     if not script:
         return {"success": False, "error": "Update script not configured"}
     return updates.rollback_updates(script)
+
+
+# ---------------------------------------------------------------------------
+# System Updates (apt update/upgrade)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/system-updates/dry-run")
+async def system_updates_dry_run():
+    return system_updates.dry_run_system_updates()
+
+
+@router.post("/system-updates/run")
+async def system_updates_run():
+    return system_updates.trigger_system_updates()
 
 
 # ---------------------------------------------------------------------------

--- a/src/linux_server_bot/bot/app.py
+++ b/src/linux_server_bot/bot/app.py
@@ -39,6 +39,7 @@ _HANDLER_MODULES = [
     handlers.sysinfo,
     handlers.security,
     handlers.updates,
+    handlers.system_updates,
     handlers.backups,
     handlers.reboot,
     handlers.scripts,

--- a/src/linux_server_bot/bot/handlers/__init__.py
+++ b/src/linux_server_bot/bot/handlers/__init__.py
@@ -13,6 +13,7 @@ from linux_server_bot.bot.handlers import (
     services,
     settings,
     sysinfo,
+    system_updates,
     updates,
     wol,
 )
@@ -30,6 +31,7 @@ __all__ = [
     "services",
     "settings",
     "sysinfo",
+    "system_updates",
     "updates",
     "wol",
 ]

--- a/src/linux_server_bot/bot/handlers/system_updates.py
+++ b/src/linux_server_bot/bot/handlers/system_updates.py
@@ -1,0 +1,87 @@
+"""System package update handler (apt update/upgrade + rkhunter)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from linux_server_bot.bot.callbacks import register_callback, safe_answer_callback_query
+from linux_server_bot.bot.menus import BTN_SYSTEM_UPDATES, inline_action_keyboard
+from linux_server_bot.shared.actions.system_updates import (
+    dry_run_system_updates,
+    trigger_system_updates,
+)
+from linux_server_bot.shared.auth import authorized
+from linux_server_bot.shared.telegram import chunk_message, escape_html, send_loading
+
+if TYPE_CHECKING:
+    import telebot
+
+    from linux_server_bot.config import AppConfig
+
+logger = logging.getLogger(__name__)
+
+_ACTIONS = [
+    ("\U0001f50d Dry run", "dry_run"),
+    ("✅ Run updates", "run"),
+]
+
+
+def register(bot: telebot.TeleBot, config: AppConfig, show_menu) -> None:
+    """Register system update handlers."""
+
+    def _send_menu(chat_id: int) -> None:
+        markup = inline_action_keyboard("sysupdate", _ACTIONS, row_width=2)
+        bot.send_message(chat_id, "System package updates:", reply_markup=markup)
+
+    def _handle_callback(bot_inst, call, parts: list[str]) -> None:
+        action = parts[0] if parts else None
+        chat_id = call.message.chat.id
+
+        if action == "cancel":
+            safe_answer_callback_query(bot_inst, call.id, "Cancelled")
+            bot_inst.edit_message_reply_markup(chat_id, call.message.message_id, reply_markup=None)
+            return
+
+        if action == "dry_run":
+            safe_answer_callback_query(bot_inst, call.id)
+            bot_inst.edit_message_reply_markup(chat_id, call.message.message_id, reply_markup=None)
+            loading = send_loading(bot_inst, chat_id, "Checking for updates")
+            result = dry_run_system_updates()
+            output = escape_html(result.get("output", "No output."))
+            chunks = chunk_message(output)
+            if chunks:
+                bot_inst.edit_message_text(chunks[0], chat_id, loading.message_id)
+                for chunk_text in chunks[1:]:
+                    bot_inst.send_message(chat_id, chunk_text)
+            return
+
+        if action == "run":
+            safe_answer_callback_query(bot_inst, call.id)
+            bot_inst.edit_message_reply_markup(chat_id, call.message.message_id, reply_markup=None)
+            loading = send_loading(bot_inst, chat_id, "System updates")
+            result = trigger_system_updates()
+            output = escape_html(result.get("output", "No output."))
+            chunks = chunk_message(output)
+            if chunks:
+                bot_inst.edit_message_text(chunks[0], chat_id, loading.message_id)
+                for chunk_text in chunks[1:]:
+                    bot_inst.send_message(chat_id, chunk_text)
+            icon = "✅" if result["success"] else "⚠️"
+            label = "System updates completed." if result["success"] else "Updates finished with errors."
+            bot_inst.send_message(chat_id, f"{icon} {label}")
+            return
+
+        safe_answer_callback_query(bot_inst, call.id, "Unknown action")
+
+    register_callback("sysupdate", _handle_callback)
+
+    @bot.message_handler(func=lambda m: m.text == BTN_SYSTEM_UPDATES)
+    @authorized(config)
+    def handle_system_updates_menu(message):
+        _send_menu(message.chat.id)
+
+    @bot.message_handler(commands=["sysupdate"])
+    @authorized(config)
+    def handle_system_updates_command(message):
+        _send_menu(message.chat.id)

--- a/src/linux_server_bot/bot/menus.py
+++ b/src/linux_server_bot/bot/menus.py
@@ -31,6 +31,7 @@ BTN_STRESS = "\U0001f4aa Stress test"
 BTN_FAN = "\U0001f4a8 Fan state"
 BTN_SECURITY = "\U0001f512 Security"
 BTN_UPDATES = "\U0001f504 Updates"
+BTN_SYSTEM_UPDATES = "\U0001f4e6 System Update"
 BTN_BACKUPS = "\U0001f4be Backups"
 BTN_REBOOT = "\U0001f501 Reboot"
 BTN_SCRIPTS = "\U0001f4dc Scripts"
@@ -50,6 +51,7 @@ _FEATURE_BUTTONS: list[tuple[str, str]] = [
     ("fan_control", BTN_FAN),
     ("security_overview", BTN_SECURITY),
     ("container_updates", BTN_UPDATES),
+    ("system_updates", BTN_SYSTEM_UPDATES),
     ("backups", BTN_BACKUPS),
     ("reboot", BTN_REBOOT),
     ("custom_scripts", BTN_SCRIPTS),

--- a/src/linux_server_bot/config.py
+++ b/src/linux_server_bot/config.py
@@ -137,6 +137,7 @@ class FeaturesConfig:
     security_overview: bool = True
     backups: bool = True
     container_updates: bool = True
+    system_updates: bool = True
     logs: bool = True
     server_ping: bool = True
     system_info: bool = True

--- a/src/linux_server_bot/shared/actions/system_updates.py
+++ b/src/linux_server_bot/shared/actions/system_updates.py
@@ -1,0 +1,58 @@
+"""System package update actions -- shared between bot and API."""
+
+from __future__ import annotations
+
+import logging
+
+from linux_server_bot.shared.shell import run_command, run_shell
+
+logger = logging.getLogger(__name__)
+
+_APT_TIMEOUT = 600
+
+
+def _rkhunter_installed() -> bool:
+    result = run_shell("command -v rkhunter", timeout=5)
+    return result.success
+
+
+def dry_run_system_updates() -> dict:
+    """Show available system package updates without installing."""
+    logger.info("System update dry-run")
+    result = run_command(["sudo", "apt-get", "update"], timeout=_APT_TIMEOUT)
+    if not result.success:
+        return {"success": False, "output": result.stdout + "\n" + result.stderr}
+
+    upgradable = run_command(["apt", "list", "--upgradable"], timeout=30)
+    output = result.stdout + "\n" + upgradable.stdout
+    return {"success": True, "output": output}
+
+
+def trigger_system_updates() -> dict:
+    """Run apt update && apt upgrade -y, then rkhunter --propupd if installed."""
+    logger.info("Triggering system updates")
+    lines: list[str] = []
+
+    update = run_command(["sudo", "apt-get", "update"], timeout=_APT_TIMEOUT)
+    lines.append(update.stdout)
+    if not update.success:
+        lines.append(update.stderr)
+        return {"success": False, "output": "\n".join(lines)}
+
+    upgrade = run_command(
+        ["sudo", "apt-get", "upgrade", "-y"],
+        timeout=_APT_TIMEOUT,
+    )
+    lines.append(upgrade.stdout)
+    if upgrade.stderr:
+        lines.append(upgrade.stderr)
+
+    if upgrade.success and _rkhunter_installed():
+        logger.info("rkhunter detected, running --propupd")
+        rk = run_command(["sudo", "rkhunter", "--propupd"], timeout=120)
+        lines.append("\n--- rkhunter --propupd ---")
+        lines.append(rk.stdout)
+        if rk.stderr:
+            lines.append(rk.stderr)
+
+    return {"success": upgrade.success, "output": "\n".join(lines)}


### PR DESCRIPTION
## Summary
- New **System Update** menu button (`📦 System Update`) and `/sysupdate` command
- Runs `apt-get update && apt-get upgrade -y` on the host
- Automatically runs `rkhunter --propupd` after a successful upgrade if rkhunter is installed
- Dry-run option to preview available updates without installing
- API endpoints: `POST /api/system-updates/dry-run` and `POST /api/system-updates/run`
- Feature flag `system_updates` to toggle on/off in config.yaml

## Test plan
- [ ] Deploy bot and verify `📦 System Update` button appears in main menu
- [ ] Test dry-run: should show available updates without installing
- [ ] Test run: should run full apt upgrade and show rkhunter output if installed
- [ ] Test API endpoints via curl
- [ ] Disable feature flag and verify button is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)