### PR TITLE
Add confirmation step before system updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ config.prod.yaml
 
 #Claude
 .claude
+pi-telegrambot-old

--- a/agent/ENDPOINTS.md
+++ b/agent/ENDPOINTS.md
@@ -475,17 +475,17 @@ Error when script not configured:
 
 Runs `apt-get update && apt-get upgrade -y` on the host. If rkhunter is installed, `rkhunter --propupd` is run automatically after a successful upgrade.
 
-### `POST /api/system-updates/dry-run`
+### `POST /api/system-updates/check`
 
-Run `apt-get update` and list upgradable packages without installing.
+Run `apt-get update` and list upgradable packages without installing. Returns the package list, count, and whether rkhunter is installed.
 
 ```json
-{"success": true, "output": "Reading package lists...\nListing... Done\nnginx/stable 1.26.0-1 amd64 [upgradable from: 1.25.4-1]"}
+{"success": true, "count": 3, "packages": ["nginx/stable 1.26.0-1 amd64 [upgradable from: 1.25.4-1]", "..."], "rkhunter": true, "output": "..."}
 ```
 
-### `POST /api/system-updates/run`
+### `POST /api/system-updates/apply`
 
-Execute the full system update.
+Execute `apt-get upgrade -y`. If rkhunter is installed, runs `rkhunter --propupd` afterwards.
 
 ```json
 {"success": true, "output": "Reading package lists...\n...\n--- rkhunter --propupd ---\n[ Rootkit Hunter version 1.4.6 ]\nFile updated: ..."}

--- a/src/linux_server_bot/api/routes.py
+++ b/src/linux_server_bot/api/routes.py
@@ -359,14 +359,14 @@ async def updates_rollback():
 # ---------------------------------------------------------------------------
 
 
-@router.post("/system-updates/dry-run")
-async def system_updates_dry_run():
-    return system_updates.dry_run_system_updates()
+@router.post("/system-updates/check")
+async def system_updates_check():
+    return system_updates.check_system_updates()
 
 
-@router.post("/system-updates/run")
-async def system_updates_run():
-    return system_updates.trigger_system_updates()
+@router.post("/system-updates/apply")
+async def system_updates_apply():
+    return system_updates.apply_system_updates()
 
 
 # ---------------------------------------------------------------------------

--- a/src/linux_server_bot/bot/handlers/system_updates.py
+++ b/src/linux_server_bot/bot/handlers/system_updates.py
@@ -6,10 +6,14 @@ import logging
 from typing import TYPE_CHECKING
 
 from linux_server_bot.bot.callbacks import register_callback, safe_answer_callback_query
-from linux_server_bot.bot.menus import BTN_SYSTEM_UPDATES, inline_action_keyboard
+from linux_server_bot.bot.menus import (
+    BTN_SYSTEM_UPDATES,
+    inline_action_keyboard,
+    inline_confirm_keyboard,
+)
 from linux_server_bot.shared.actions.system_updates import (
-    dry_run_system_updates,
-    trigger_system_updates,
+    apply_system_updates,
+    check_system_updates,
 )
 from linux_server_bot.shared.auth import authorized
 from linux_server_bot.shared.telegram import chunk_message, escape_html, send_loading
@@ -22,9 +26,30 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _ACTIONS = [
-    ("\U0001f50d Dry run", "dry_run"),
+    ("\U0001f50d Check updates", "check"),
     ("✅ Run updates", "run"),
 ]
+
+
+def _format_check_result(result: dict) -> str:
+    """Format the update check result for Telegram."""
+    count = result["count"]
+    packages = result["packages"]
+    rkhunter = result.get("rkhunter", False)
+
+    if count == 0:
+        return "✅ System is up to date. No packages to upgrade."
+
+    lines = [f"\U0001f4e6 <b>{count} package(s) available for upgrade:</b>\n"]
+    for pkg in packages:
+        lines.append(f"  • {escape_html(pkg)}")
+
+    lines.append(f"\n\U0001f4cb <b>This will run:</b>")
+    lines.append("  <code>sudo apt-get upgrade -y</code>")
+    if rkhunter:
+        lines.append("  <code>sudo rkhunter --propupd</code>")
+
+    return "\n".join(lines)
 
 
 def register(bot: telebot.TeleBot, config: AppConfig, show_menu) -> None:
@@ -43,34 +68,83 @@ def register(bot: telebot.TeleBot, config: AppConfig, show_menu) -> None:
             bot_inst.edit_message_reply_markup(chat_id, call.message.message_id, reply_markup=None)
             return
 
-        if action == "dry_run":
+        if action == "check":
             safe_answer_callback_query(bot_inst, call.id)
             bot_inst.edit_message_reply_markup(chat_id, call.message.message_id, reply_markup=None)
             loading = send_loading(bot_inst, chat_id, "Checking for updates")
-            result = dry_run_system_updates()
-            output = escape_html(result.get("output", "No output."))
-            chunks = chunk_message(output)
-            if chunks:
-                bot_inst.edit_message_text(chunks[0], chat_id, loading.message_id)
-                for chunk_text in chunks[1:]:
-                    bot_inst.send_message(chat_id, chunk_text)
+            result = check_system_updates()
+
+            if not result["success"]:
+                output = escape_html(result.get("output", "Failed to check for updates."))
+                chunks = chunk_message(output)
+                if chunks:
+                    bot_inst.edit_message_text(chunks[0], chat_id, loading.message_id)
+                    for chunk_text in chunks[1:]:
+                        bot_inst.send_message(chat_id, chunk_text)
+                return
+
+            text = _format_check_result(result)
+            bot_inst.edit_message_text(text, chat_id, loading.message_id, parse_mode="HTML")
+
+            if result["count"] > 0:
+                markup = inline_confirm_keyboard("sysupdate", "confirm_upgrade")
+                bot_inst.send_message(
+                    chat_id,
+                    f"Apply {result['count']} update(s)?",
+                    reply_markup=markup,
+                )
             return
 
         if action == "run":
             safe_answer_callback_query(bot_inst, call.id)
             bot_inst.edit_message_reply_markup(chat_id, call.message.message_id, reply_markup=None)
-            loading = send_loading(bot_inst, chat_id, "System updates")
-            result = trigger_system_updates()
-            output = escape_html(result.get("output", "No output."))
-            chunks = chunk_message(output)
-            if chunks:
-                bot_inst.edit_message_text(chunks[0], chat_id, loading.message_id)
-                for chunk_text in chunks[1:]:
-                    bot_inst.send_message(chat_id, chunk_text)
-            icon = "✅" if result["success"] else "⚠️"
-            label = "System updates completed." if result["success"] else "Updates finished with errors."
-            bot_inst.send_message(chat_id, f"{icon} {label}")
+            loading = send_loading(bot_inst, chat_id, "Checking for updates")
+            result = check_system_updates()
+
+            if not result["success"]:
+                output = escape_html(result.get("output", "Failed to check for updates."))
+                chunks = chunk_message(output)
+                if chunks:
+                    bot_inst.edit_message_text(chunks[0], chat_id, loading.message_id)
+                    for chunk_text in chunks[1:]:
+                        bot_inst.send_message(chat_id, chunk_text)
+                return
+
+            text = _format_check_result(result)
+            bot_inst.edit_message_text(text, chat_id, loading.message_id, parse_mode="HTML")
+
+            if result["count"] == 0:
+                return
+
+            markup = inline_confirm_keyboard("sysupdate", "confirm_upgrade")
+            bot_inst.send_message(
+                chat_id,
+                f"Apply {result['count']} update(s)?",
+                reply_markup=markup,
+            )
             return
+
+        if action == "confirm_upgrade":
+            confirm = parts[1] if len(parts) > 1 else None
+            if confirm == "cancel":
+                safe_answer_callback_query(bot_inst, call.id, "Cancelled")
+                bot_inst.edit_message_reply_markup(chat_id, call.message.message_id, reply_markup=None)
+                return
+            if confirm == "confirm":
+                safe_answer_callback_query(bot_inst, call.id)
+                bot_inst.edit_message_reply_markup(chat_id, call.message.message_id, reply_markup=None)
+                loading = send_loading(bot_inst, chat_id, "Installing updates")
+                result = apply_system_updates()
+                output = escape_html(result.get("output", "No output."))
+                chunks = chunk_message(output)
+                if chunks:
+                    bot_inst.edit_message_text(chunks[0], chat_id, loading.message_id)
+                    for chunk_text in chunks[1:]:
+                        bot_inst.send_message(chat_id, chunk_text)
+                icon = "✅" if result["success"] else "⚠️"
+                label = "System updates completed." if result["success"] else "Updates finished with errors."
+                bot_inst.send_message(chat_id, f"{icon} {label}")
+                return
 
         safe_answer_callback_query(bot_inst, call.id, "Unknown action")
 

--- a/src/linux_server_bot/shared/actions/system_updates.py
+++ b/src/linux_server_bot/shared/actions/system_updates.py
@@ -16,28 +16,44 @@ def _rkhunter_installed() -> bool:
     return result.success
 
 
-def dry_run_system_updates() -> dict:
-    """Show available system package updates without installing."""
-    logger.info("System update dry-run")
-    result = run_command(["sudo", "apt-get", "update"], timeout=_APT_TIMEOUT)
-    if not result.success:
-        return {"success": False, "output": result.stdout + "\n" + result.stderr}
+def _parse_upgradable(output: str) -> list[str]:
+    """Extract package lines from `apt list --upgradable` output."""
+    lines = []
+    for line in output.strip().splitlines():
+        if line.startswith("Listing") or not line.strip():
+            continue
+        lines.append(line)
+    return lines
+
+
+def check_system_updates() -> dict:
+    """Run apt update and list available upgrades without installing."""
+    logger.info("Checking for system updates")
+    update = run_command(["sudo", "apt-get", "update"], timeout=_APT_TIMEOUT)
+    if not update.success:
+        return {
+            "success": False,
+            "packages": [],
+            "count": 0,
+            "output": update.stdout + "\n" + update.stderr,
+        }
 
     upgradable = run_command(["apt", "list", "--upgradable"], timeout=30)
-    output = result.stdout + "\n" + upgradable.stdout
-    return {"success": True, "output": output}
+    packages = _parse_upgradable(upgradable.stdout)
+
+    return {
+        "success": True,
+        "packages": packages,
+        "count": len(packages),
+        "rkhunter": _rkhunter_installed(),
+        "output": update.stdout + "\n" + upgradable.stdout,
+    }
 
 
-def trigger_system_updates() -> dict:
-    """Run apt update && apt upgrade -y, then rkhunter --propupd if installed."""
-    logger.info("Triggering system updates")
+def apply_system_updates() -> dict:
+    """Run apt upgrade -y, then rkhunter --propupd if installed."""
+    logger.info("Applying system updates")
     lines: list[str] = []
-
-    update = run_command(["sudo", "apt-get", "update"], timeout=_APT_TIMEOUT)
-    lines.append(update.stdout)
-    if not update.success:
-        lines.append(update.stderr)
-        return {"success": False, "output": "\n".join(lines)}
 
     upgrade = run_command(
         ["sudo", "apt-get", "upgrade", "-y"],


### PR DESCRIPTION
## Summary
- Both "Check updates" and "Run updates" now first show an overview before upgrading
- Shows number of available packages, full package list, and which commands will run
- User must confirm via inline button before `apt-get upgrade -y` actually executes
- API endpoints renamed to `POST /system-updates/check` and `POST /system-updates/apply`

## Test plan
- [ ] Tap "Check updates" — should show package list without installing
- [ ] Tap "Run updates" — should show package list + confirm/cancel buttons
- [ ] Tap "Confirm" — should run the actual upgrade + rkhunter if installed
- [ ] Tap "Cancel" — should abort without changes
- [ ] Test with 0 available updates — should show "System is up to date" without confirm button

🤖 Generated with [Claude Code](https://claude.com/claude-code)