### PR TITLE
Fix Docker bind-mount bug + compose host-context fix + doc updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Environment and config
 .env
 config.yaml
+config/config.yaml
 server_states.json
 .setup_state.json
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Open the menu with `/menu` or a bot command and manage your server on-demand: st
 
 ### 📡 Background Monitoring
 
-The bot continuously watches your server and sends you a message when something needs attention. Only services and containers explicitly listed in `config.yaml` are monitored -- giving you full control over what gets checked.
+The bot continuously watches your server and sends you a message when something needs attention. Only services and containers explicitly listed in `config/config.yaml` are monitored -- giving you full control over what gets checked.
 
 **What it monitors:**
 
@@ -69,7 +69,7 @@ The bot continuously watches your server and sends you a message when something 
 | SSH failed logins | Alert on brute force attempts (>10 failures) |
 | Fail2ban bans | Alert when an IP gets banned |
 
-Services and containers are configured in `config.yaml` under `services` and `containers` (one list each, used by both the bot menu and monitoring). You can add/remove items and change failure policies via the Telegram bot menu, the API, or directly in `config.yaml`.
+Services and containers are configured in `config/config.yaml` under `services` and `containers` (one list each, used by both the bot menu and monitoring). You can add/remove items and change failure policies via the Telegram bot menu, the API, or directly in `config/config.yaml`.
 
 ### 🌐 HTTP API (Optional)
 
@@ -95,7 +95,7 @@ Telegram Chat
                                                ──> netcat              ──> Server Pings
 ```
 
-All processes share a single `config.yaml` with hot-reload support (edit while running, changes are picked up automatically).
+All processes share a single `config/config.yaml` with hot-reload support (edit while running, changes are picked up automatically).
 
 > [!NOTE]
 > **Docker host access**: The containers run in `privileged` mode with `pid: host`. Commands that need host binaries (systemctl, ufw, fail2ban-client, etc.) are automatically wrapped with `nsenter -t 1 -m --` to run in the host's mount namespace. This is transparent -- you don't need to do anything special.
@@ -466,7 +466,7 @@ docker exec linux-server-bot nsenter -t 1 -m -- systemctl is-active docker
 
 ```bash
 docker compose logs monitoring --tail 20
-# Only services/containers listed in config.yaml are monitored.
+# Only services/containers listed in config/config.yaml are monitored.
 # Check the failure policy is not set to 'ignore'.
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The API makes this bot a natural fit for **AI agents**: give your agent the [ski
 Telegram Chat ──── Bot ──────┐
                              ├──> shared/actions/ ──> Docker / systemd / shell
 AI Agent ─────── REST API ───┘
-                               ▲ single config.yaml (hot-reloadable)
+                               ▲ single config/config.yaml (hot-reloadable)
 ```
 
 <img src="example.jpg" alt="Telegram bot interface" width="250">
@@ -117,7 +117,7 @@ cd linux-server-telegram-bot
 
 # Copy example configs
 cp .env.example .env
-cp config.example.yaml config.yaml
+mkdir -p config && cp config.example.yaml config/config.yaml
 ```
 
 Edit `.env` with the credentials from step 1:
@@ -161,9 +161,11 @@ docker compose logs -f
 | `WOL_ADDRESS` | No | MAC address for Wake-on-LAN (menu button hidden when empty) |
 | `WOL_HOSTNAME` | No | Display name for the WoL device |
 
-### config.yaml
+### config/config.yaml
 
-All settings are in `config.yaml` with `${VAR}` syntax for environment variable references. Changes are picked up automatically (hot-reload). See [`config.example.yaml`](config.example.yaml) for a complete reference.
+All settings are in `config/config.yaml` with `${VAR}` syntax for environment variable references. Changes are picked up automatically (hot-reload). See [`config.example.yaml`](config.example.yaml) for a complete reference.
+
+> **Upgrading from 2.x?** The live config moved from `./config.yaml` to `./config/config.yaml` to fix a Docker single-file bind-mount bug that silently dropped threshold updates. Run `./tools/migrate-config-layout.sh` once before `docker compose up -d`. Host-native runs migrate automatically on next startup.
 
 #### Services and containers
 

--- a/agent/ENDPOINTS.md
+++ b/agent/ENDPOINTS.md
@@ -253,7 +253,7 @@ curl -s -H "X-API-Key: $KEY" $URL/sysinfo
 
 ### `POST /api/sysinfo/stress-test?minutes=1`
 
-Run a CPU stress test. Requires `features.stress_test: true` in config.yaml. Duration: 1--60 minutes.
+Run a CPU stress test. Requires `features.stress_test: true` in config/config.yaml. Duration: 1--60 minutes.
 
 ```bash
 curl -s -X POST -H "X-API-Key: $KEY" "$URL/sysinfo/stress-test?minutes=2"
@@ -271,7 +271,7 @@ Feature disabled:
 
 ### `POST /api/sysinfo/fan?state=0`
 
-Set fan state. Requires `features.fan_control: true` in config.yaml (typically Raspberry Pi only). `0` = off/auto, `1` = on.
+Set fan state. Requires `features.fan_control: true` in config/config.yaml (typically Raspberry Pi only). `0` = off/auto, `1` = on.
 
 ```bash
 curl -s -X POST -H "X-API-Key: $KEY" "$URL/sysinfo/fan?state=1"
@@ -461,7 +461,7 @@ Execute `apt-get upgrade -y`. If rkhunter is installed, runs `rkhunter --propupd
 
 ### Container Updates (via script)
 
-Requires `scripts.update_containers` to be configured in config.yaml (path to [update-containers.sh](https://github.com/Made-By-Adem/linux-server-management-scripts)).
+Requires `scripts.update_containers` to be configured in config/config.yaml (path to [update-containers.sh](https://github.com/Made-By-Adem/linux-server-management-scripts)).
 
 #### `POST /api/updates/dry-run`
 
@@ -497,7 +497,7 @@ Error when script not configured:
 
 ## Backups
 
-Requires `scripts.backup` to be configured in config.yaml (path to [backup.sh](https://github.com/Made-By-Adem/linux-server-management-scripts)).
+Requires `scripts.backup` to be configured in config/config.yaml (path to [backup.sh](https://github.com/Made-By-Adem/linux-server-management-scripts)).
 
 ### `POST /api/backups/trigger`
 
@@ -684,7 +684,7 @@ curl -s -X PUT -H "X-API-Key: $KEY" -H "Content-Type: application/json" \
 
 ### `POST /api/config/reload`
 
-Hot-reload config.yaml without restarting services.
+Hot-reload config/config.yaml without restarting services.
 
 ```bash
 curl -s -X POST -H "X-API-Key: $KEY" $URL/config/reload

--- a/agent/README.md
+++ b/agent/README.md
@@ -19,7 +19,7 @@ This directory contains everything an AI agent needs to manage Linux servers via
 
 ### 1. Deploy the API on your server(s)
 
-Follow the main [README](../README.md) to deploy the bot + API via Docker Compose. Ensure the API section is enabled in `config.yaml`:
+Follow the main [README](../README.md) to deploy the bot + API via Docker Compose. Ensure the API section is enabled in `config/config.yaml`:
 
 ```yaml
 api:

--- a/agent/SKILL.md
+++ b/agent/SKILL.md
@@ -33,7 +33,7 @@ All endpoints return JSON with a `success` boolean:
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/api/health` | Health check (no auth) |
-| POST | `/api/config/reload` | Hot-reload config.yaml |
+| POST | `/api/config/reload` | Hot-reload config/config.yaml |
 
 ### Docker Containers
 
@@ -173,8 +173,8 @@ In the Telegram bot these are combined under one "Updates + Containers" button. 
 
 ## Important Notes
 
-- **Container and service names** are explicitly configured in config.yaml -- only configured items are monitored. Use the CRUD endpoints to add/remove items at runtime.
+- **Container and service names** are explicitly configured in config/config.yaml -- only configured items are monitored. Use the CRUD endpoints to add/remove items at runtime.
 - **Updates and backups** require external scripts to be installed (from [linux-server-management-scripts](https://github.com/Made-By-Adem/linux-server-management-scripts))
 - **Reboot** requires explicit `{"confirm": true}` -- will not execute without it
 - **Command execution** runs with server-level privileges -- use with caution
-- **Config reload** picks up changes to config.yaml without restarting services
+- **Config reload** picks up changes to config/config.yaml without restarting services

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,7 @@
 # Linux Server Bot - Configuration
 # Environment variables can be referenced with ${VAR_NAME} syntax.
-# Copy this file to config.yaml and adjust values.
+# Copy this file to config/config.yaml and adjust values:
+#   mkdir -p config && cp config.example.yaml config/config.yaml
 
 telegram:
   bot_token: ${SECRET_TOKEN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,10 @@ services:
     command: linux-bot
     env_file: .env
     environment:
-      CONFIG_PATH: /app/config.yaml
+      CONFIG_PATH: /app/config/config.yaml
     volumes:
       - ./.env:/app/.env
-      - ./config.yaml:/app/config.yaml
+      - ./config:/app/config
       - ./logs/bot:/app/logs
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
@@ -32,10 +32,10 @@ services:
     command: linux-monitor
     env_file: .env
     environment:
-      CONFIG_PATH: /app/config.yaml
+      CONFIG_PATH: /app/config/config.yaml
     volumes:
       - ./.env:/app/.env
-      - ./config.yaml:/app/config.yaml
+      - ./config:/app/config
       - ./logs/monitoring:/app/logs
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
@@ -55,12 +55,12 @@ services:
     command: linux-api
     env_file: .env
     environment:
-      CONFIG_PATH: /app/config.yaml
+      CONFIG_PATH: /app/config/config.yaml
     ports:
       - "8120:8120"
     volumes:
       - ./.env:/app/.env
-      - ./config.yaml:/app/config.yaml
+      - ./config:/app/config
       - ./logs/api:/app/logs
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket

--- a/src/linux_server_bot/api/routes.py
+++ b/src/linux_server_bot/api/routes.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 def _config_path() -> str:
-    return os.environ.get("CONFIG_PATH", "config.yaml")
+    return os.environ.get("CONFIG_PATH", "config/config.yaml")
 
 
 router = APIRouter(prefix="/api", dependencies=[Depends(verify_api_key)])

--- a/src/linux_server_bot/api/server.py
+++ b/src/linux_server_bot/api/server.py
@@ -15,6 +15,7 @@ from linux_server_bot.shared.logging_setup import setup_logging
 from linux_server_bot.shared.shell import warmup as shell_warmup
 from linux_server_bot.shared.startup import (
     ensure_env,
+    migrate_legacy_config_path,
     print_banner,
     setup_graceful_shutdown,
 )
@@ -50,7 +51,8 @@ def main() -> None:
     # Graceful shutdown on SIGINT/SIGTERM
     setup_graceful_shutdown()
 
-    config_path = os.environ.get("CONFIG_PATH", "config.yaml")
+    config_path = os.environ.get("CONFIG_PATH", "config/config.yaml")
+    migrate_legacy_config_path(config_path)
     load_config(config_path)
 
     setup_logging("api", config.log_directory)

--- a/src/linux_server_bot/bot/app.py
+++ b/src/linux_server_bot/bot/app.py
@@ -18,6 +18,7 @@ from linux_server_bot.shared.logging_setup import setup_logging
 from linux_server_bot.shared.shell import warmup as shell_warmup
 from linux_server_bot.shared.startup import (
     ensure_env,
+    migrate_legacy_config_path,
     print_banner,
     run_preflight_checks,
     setup_graceful_shutdown,
@@ -224,7 +225,8 @@ def main() -> None:
     setup_graceful_shutdown()
 
     # Load config (starts watchdog file watcher)
-    config_path = os.environ.get("CONFIG_PATH", "config.yaml")
+    config_path = os.environ.get("CONFIG_PATH", "config/config.yaml")
+    migrate_legacy_config_path(config_path)
     load_config(config_path)
     logger.info("[boot] config loaded (%.1fs)", time.monotonic() - boot_t0)
 

--- a/src/linux_server_bot/bot/handlers/docker.py
+++ b/src/linux_server_bot/bot/handlers/docker.py
@@ -84,7 +84,7 @@ def _send_status(bot, chat_id: int, config) -> None:
 
 
 def _get_config_path() -> str:
-    return os.environ.get("CONFIG_PATH", "config.yaml")
+    return os.environ.get("CONFIG_PATH", "config/config.yaml")
 
 
 def _send_policy_overview(bot, chat_id: int, config) -> None:

--- a/src/linux_server_bot/bot/handlers/services.py
+++ b/src/linux_server_bot/bot/handlers/services.py
@@ -78,7 +78,7 @@ def register(bot: telebot.TeleBot, config: AppConfig, show_menu) -> None:
     """Register all service management handlers."""
 
     def _get_config_path() -> str:
-        return os.environ.get("CONFIG_PATH", "config.yaml")
+        return os.environ.get("CONFIG_PATH", "config/config.yaml")
 
     def _send_policy_overview(bot_inst, chat_id: int) -> None:
         """Show current monitoring policies for all configured services."""

--- a/src/linux_server_bot/bot/handlers/settings.py
+++ b/src/linux_server_bot/bot/handlers/settings.py
@@ -46,7 +46,7 @@ def register(bot: telebot.TeleBot, config: AppConfig, show_menu) -> None:
     """Register settings handlers."""
 
     def _get_config_path() -> str:
-        return os.environ.get("CONFIG_PATH", "config.yaml")
+        return os.environ.get("CONFIG_PATH", "config/config.yaml")
 
     def _send_settings(bot_inst, chat_id: int) -> None:
         """Show all features with their current state and toggle buttons."""

--- a/src/linux_server_bot/bot/handlers/sysinfo.py
+++ b/src/linux_server_bot/bot/handlers/sysinfo.py
@@ -182,7 +182,7 @@ def register(bot: telebot.TeleBot, config: AppConfig, show_menu) -> None:
             return
 
         try:
-            update_monitoring_threshold(key, value, os.environ.get("CONFIG_PATH", "config.yaml"))
+            update_monitoring_threshold(key, value, os.environ.get("CONFIG_PATH", "config/config.yaml"))
             label, unit = _THRESHOLD_LABELS[key]
             bot.send_message(
                 message.chat.id,

--- a/src/linux_server_bot/bot/handlers/updates.py
+++ b/src/linux_server_bot/bot/handlers/updates.py
@@ -51,7 +51,7 @@ def _format_check_result(result: dict) -> str:
     for pkg in packages:
         lines.append(f"  • {escape_html(pkg)}")
 
-    lines.append(f"\n\U0001f4cb <b>This will run:</b>")
+    lines.append("\n\U0001f4cb <b>This will run:</b>")
     lines.append("  <code>sudo apt-get upgrade -y</code>")
     if rkhunter:
         lines.append("  <code>sudo rkhunter --propupd</code>")
@@ -150,7 +150,10 @@ def register(bot: telebot.TeleBot, config: AppConfig, show_menu) -> None:
             script = _check_script()
             if not script:
                 safe_answer_callback_query(bot_inst, call.id, "Script not configured")
-                bot_inst.send_message(chat_id, "Update script not configured in config.yaml (scripts.update_containers).")
+                bot_inst.send_message(
+                    chat_id,
+                    "Update script not configured in config.yaml (scripts.update_containers).",
+                )
                 return
             safe_answer_callback_query(bot_inst, call.id)
             bot_inst.edit_message_reply_markup(chat_id, call.message.message_id, reply_markup=None)
@@ -164,7 +167,10 @@ def register(bot: telebot.TeleBot, config: AppConfig, show_menu) -> None:
             script = _check_script()
             if not script:
                 safe_answer_callback_query(bot_inst, call.id, "Script not configured")
-                bot_inst.send_message(chat_id, "Update script not configured in config.yaml (scripts.update_containers).")
+                bot_inst.send_message(
+                    chat_id,
+                    "Update script not configured in config.yaml (scripts.update_containers).",
+                )
                 return
             safe_answer_callback_query(bot_inst, call.id)
             bot_inst.edit_message_reply_markup(chat_id, call.message.message_id, reply_markup=None)
@@ -181,7 +187,10 @@ def register(bot: telebot.TeleBot, config: AppConfig, show_menu) -> None:
             script = _check_script()
             if not script:
                 safe_answer_callback_query(bot_inst, call.id, "Script not configured")
-                bot_inst.send_message(chat_id, "Update script not configured in config.yaml (scripts.update_containers).")
+                bot_inst.send_message(
+                    chat_id,
+                    "Update script not configured in config.yaml (scripts.update_containers).",
+                )
                 return
             safe_answer_callback_query(bot_inst, call.id)
             bot_inst.edit_message_reply_markup(chat_id, call.message.message_id, reply_markup=None)

--- a/src/linux_server_bot/config.py
+++ b/src/linux_server_bot/config.py
@@ -16,7 +16,8 @@ from watchdog.observers.polling import PollingObserver
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_CONFIG_PATH = Path("config.yaml")
+_DEFAULT_CONFIG_PATH = Path("config/config.yaml")
+_LEGACY_CONFIG_PATH = Path("config.yaml")
 _ENV_VAR_PATTERN = re.compile(r"\$\{(\w+)\}")
 _DEBOUNCE_SECONDS = 0.5
 

--- a/src/linux_server_bot/monitoring/app.py
+++ b/src/linux_server_bot/monitoring/app.py
@@ -15,6 +15,7 @@ from linux_server_bot.shared.logging_setup import setup_logging
 from linux_server_bot.shared.shell import warmup as shell_warmup
 from linux_server_bot.shared.startup import (
     ensure_env,
+    migrate_legacy_config_path,
     print_banner,
     run_preflight_checks,
     setup_graceful_shutdown,
@@ -61,7 +62,8 @@ def main() -> None:
     # Graceful shutdown on SIGINT/SIGTERM
     setup_graceful_shutdown()
 
-    config_path = os.environ.get("CONFIG_PATH", "config.yaml")
+    config_path = os.environ.get("CONFIG_PATH", "config/config.yaml")
+    migrate_legacy_config_path(config_path)
     load_config(config_path)
 
     setup_logging("monitoring", config.log_directory)

--- a/src/linux_server_bot/shared/actions/compose.py
+++ b/src/linux_server_bot/shared/actions/compose.py
@@ -12,6 +12,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Order matters: compose v2 prefers .yaml, but .yml is still common.
+_COMPOSE_FILENAMES = ("docker-compose.yaml", "docker-compose.yml", "compose.yaml", "compose.yml")
+
 
 def _looks_like_missing_compose_v2(result) -> bool:
     """Detect cases where ``docker compose`` is unavailable/incompatible."""
@@ -19,10 +22,34 @@ def _looks_like_missing_compose_v2(result) -> bool:
     return "unknown shorthand flag: 'f' in -f" in error_text or "'compose' is not a docker command" in error_text
 
 
+def _compose_file(path: str) -> str:
+    """Return ``"<path>/<filename>"`` for the first compose file that exists.
+
+    Probes for the standard names via ``ls`` on the host (so it works the
+    same whether the bot runs in Docker or natively). Falls back to the
+    canonical ``docker-compose.yaml`` so error messages stay informative.
+    """
+    probe = run_command(["ls"] + [f"{path}/{name}" for name in _COMPOSE_FILENAMES], force_host=True)
+    for line in probe.stdout.splitlines():
+        line = line.strip()
+        if line.startswith(path + "/"):
+            return line
+    return f"{path}/docker-compose.yaml"
+
+
 def _compose_cmd(path: str, args: list[str], timeout: int = 120):
+    """Run ``docker compose -f <stack>/<file> <args>`` against the host.
+
+    The compose file lives on the host filesystem and is rarely mounted
+    into the bot container, so the call is forced through nsenter to
+    enter the host's mount namespace. The host's docker CLI talks to
+    the same daemon via the shared docker socket either way.
+    """
+    compose_file = _compose_file(path)
     result = run_command(
-        ["docker", "compose", "-f", f"{path}/docker-compose.yml"] + args,
+        ["docker", "compose", "-f", compose_file] + args,
         timeout=timeout,
+        force_host=True,
     )
     if not result.success and _looks_like_missing_compose_v2(result):
         result.stderr = (

--- a/src/linux_server_bot/shared/shell.py
+++ b/src/linux_server_bot/shared/shell.py
@@ -83,6 +83,7 @@ def run_command(
     cmd: list[str],
     timeout: int = _DEFAULT_TIMEOUT,
     check: bool = False,
+    force_host: bool = False,
 ) -> ShellResult:
     """Run a command as a list of arguments (no shell interpolation).
 
@@ -90,7 +91,9 @@ def run_command(
     are known at construction time (systemctl, docker, nc, etherwake, etc.).
 
     When running in Docker with pid:host, commands that require host binaries
-    are automatically wrapped with ``nsenter -t 1 -m --``.
+    are automatically wrapped with ``nsenter -t 1 -m --``. Use ``force_host=True``
+    for commands that read host filesystem paths even though the binary itself
+    runs fine inside the container (e.g. ``docker compose -f /host/path/...``).
     """
     # Determine the actual binary (skip sudo to check the real command)
     first_cmd = cmd[0]
@@ -100,7 +103,8 @@ def run_command(
         actual_cmd = first_cmd
 
     # Wrap with nsenter if needed
-    if _needs_nsenter(actual_cmd) and _nsenter_available():
+    needs_host = force_host or _needs_nsenter(actual_cmd)
+    if _in_docker() and needs_host and _nsenter_available():
         cmd = ["nsenter", "-t", "1", "-m", "--"] + cmd
         logger.debug("run_command (nsenter): %s", " ".join(cmd))
     else:

--- a/src/linux_server_bot/shared/startup.py
+++ b/src/linux_server_bot/shared/startup.py
@@ -277,6 +277,49 @@ def run_setup_wizard(env_path: str) -> None:
     print("  Setup complete! Starting the bot...\n")
 
 
+def migrate_legacy_config_path(config_path: str) -> None:
+    """Move a top-level ``config.yaml`` into the new ``config/`` directory.
+
+    The 2.x layout placed ``config.yaml`` at the repo root and bind-mounted
+    it as a single file in Docker. Single-file bind mounts break when an
+    editor (vim, Claude Edit, …) replaces the host file via atomic rename:
+    the container ends up writing to an orphaned inode, so threshold
+    updates from the bot never reach the host. The 2.1 layout puts the
+    file inside ``config/`` and mounts the directory instead.
+
+    This helper migrates an old layout in place when both conditions hold:
+
+    * ``config_path`` (the new location) does not exist yet
+    * a legacy ``config.yaml`` exists next to it (or in the cwd)
+
+    Runs only on the host side: in Docker, the legacy file is no longer
+    mounted into the container, so this is a no-op there. Docker users
+    migrate via ``tools/migrate-config-layout.sh`` before ``compose up``.
+    """
+    target = os.path.abspath(config_path)
+    if os.path.exists(target):
+        return
+
+    # Look for the legacy file: either a sibling of the new config dir, or
+    # the literal "config.yaml" in cwd (host-native dev runs).
+    candidates = [
+        os.path.join(os.path.dirname(os.path.dirname(target)), "config.yaml"),
+        os.path.abspath("config.yaml"),
+    ]
+    legacy = next((p for p in candidates if os.path.exists(p) and p != target), None)
+    if legacy is None:
+        return
+
+    os.makedirs(os.path.dirname(target), exist_ok=True)
+    os.rename(legacy, target)
+    logger.warning(
+        "Migrated legacy config.yaml: %s -> %s. The 2.x single-file bind "
+        "mount has been replaced by a directory mount; see README.",
+        legacy,
+        target,
+    )
+
+
 def ensure_env(env_path: str) -> None:
     """Ensure .env exists and has required values.
 
@@ -364,7 +407,8 @@ def check_config_file(config_path: str) -> bool:
     if os.path.exists(config_path):
         return True
     logger.warning(
-        "Config file %s not found. Using defaults. Copy config.example.yaml to config.yaml to customize.",
+        "Config file %s not found. Using defaults. Copy config.example.yaml to %s to customize.",
+        config_path,
         config_path,
     )
     return False

--- a/tools/migrate-config-layout.sh
+++ b/tools/migrate-config-layout.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Migrate the legacy ./config.yaml location to ./config/config.yaml.
+#
+# 2.x bind-mounted ./config.yaml as a single file in Docker. That mount
+# breaks when an editor (vim, etc.) replaces the host file via atomic
+# rename: subsequent writes from the bot then go to an orphaned inode
+# and never reach the host. 2.1 mounts the ./config/ directory instead,
+# which is robust against atomic renames.
+#
+# Run this once on the host before `docker compose up -d` after pulling
+# the new layout. Idempotent: no-op if already migrated.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ -f config/config.yaml ]; then
+    echo "config/config.yaml already exists - nothing to migrate."
+    exit 0
+fi
+
+if [ ! -f config.yaml ]; then
+    echo "No config.yaml found at repo root. If this is a fresh install,"
+    echo "copy config.example.yaml to config/config.yaml and edit it."
+    exit 0
+fi
+
+mkdir -p config
+mv config.yaml config/config.yaml
+echo "Migrated config.yaml -> config/config.yaml"
+echo "Now run: docker compose up -d"


### PR DESCRIPTION
## Summary
Bundles three related fixes that surfaced together while testing the config-mount layout change.

### 1. Docker bind-mount bug (the original motivation)
Single-file bind mounts (`./config.yaml:/app/config.yaml`) break silently when an editor (vim, etc.) replaces the host file via atomic rename: subsequent writes from the container target an orphaned inode while the host file is unchanged. Threshold updates from the bot were saved into a ghost file that no process ever read again.

- Switch the live config to `./config/config.yaml` and bind-mount the parent directory. Directory mounts track by path, not inode, and survive atomic renames.
- Auto-migration: `migrate_legacy_config_path()` runs on bot/monitoring/api startup (host-native path), and `tools/migrate-config-layout.sh` does the same on the host before `docker compose up -d` (Docker path). Both idempotent.

### 2. Compose host-context fix
The bot uses `docker` from inside its own container, but `docker compose -f <stack>/<file>` reads a YAML file on the host filesystem. That path is rarely bind-mounted into the container, so every compose status/up/down/restart call failed with "no such file or directory" and the menu reported every stack offline.

- Add `force_host=True` to `run_command` so callers can force an nsenter wrap even for binaries that normally run in-container. The host's docker CLI talks to the same daemon via the shared socket, so only the filesystem context changes.
- `_compose_cmd` probes the stack directory for `docker-compose.yaml` / `docker-compose.yml` / `compose.yaml` / `compose.yml` instead of hardcoding `docker-compose.yml`.

### 3. Drive-by lint fix
Pre-existing lint errors in `updates.py` (1× F541, 3× E501) that were red on `main` after the pironman merge. Cleaned up so CI is green again.

### 4. Doc updates
README and agent docs (SKILL.md, ENDPOINTS.md, README.md) updated for the new `config/config.yaml` path. `config.example.yaml` stays at repo root -- it's a template, not live config.

## Test plan
- [x] Local CI mirrored: `ruff check src/`, `ruff format --check src/`, `pytest tests/` (38 passed)
- [x] Migration helper unit-checked: moves legacy `./config.yaml` → `./config/config.yaml`, no-op when target already exists
- [x] On-host upgrade path: `tools/migrate-config-layout.sh` → `docker compose up -d` → bot starts cleanly
- [x] Compose status menu: 7 stacks all reported online (verified by calling `get_stack_status` from inside the running container)
- [ ] Threshold persistence after bot restart (final user-side check)

## Upgrade note for users
After pulling, run `./tools/migrate-config-layout.sh` once before `docker compose up -d`. Host-native users get auto-migration on next startup. Already documented in README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)