### PR TITLE
Fix /sysinfo CPU: bypass broken shell /proc/stat diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,20 @@
 # Log directory
 /logs/
+*.log
 
-# Environment and config
+# Environment and secrets
 .env
+.env.*
+!.env.example
 config.yaml
 config/config.yaml
+config.prod.yaml
 server_states.json
 .setup_state.json
+*.pem
+*.key
+*.crt
+*.cert
 
 # Python
 __pycache__/
@@ -20,14 +28,29 @@ build/
 venv/
 .venv/
 
+# Test and lint caches
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.hypothesis/
+.coverage
+coverage.xml
+htmlcov/
+
 # IDE
 .vscode/
 .idea/
-config.prod.yaml
+*.swp
+*.swo
+*~
+
+# OS metadata
+.DS_Store
+Thumbs.db
 
 # Crash dumps
 *.stackdump
 
-#Claude
-.claude
+# Claude Code
+.claude/
 pi-telegrambot-old

--- a/src/linux_server_bot/api/routes.py
+++ b/src/linux_server_bot/api/routes.py
@@ -211,17 +211,17 @@ async def sysinfo_cpu():
 
 @router.get("/sysinfo/memory")
 async def sysinfo_memory():
-    return sysinfo.get_memory_usage()
+    return await asyncio.to_thread(sysinfo.get_memory_usage)
 
 
 @router.get("/sysinfo/disk")
 async def sysinfo_disk():
-    return sysinfo.get_disk_usage()
+    return await asyncio.to_thread(sysinfo.get_disk_usage)
 
 
 @router.get("/sysinfo/temperature")
 async def sysinfo_temperature():
-    return sysinfo.get_temperature()
+    return await asyncio.to_thread(sysinfo.get_temperature)
 
 
 @router.post("/sysinfo/stress-test")

--- a/src/linux_server_bot/api/routes.py
+++ b/src/linux_server_bot/api/routes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from dataclasses import asdict
@@ -199,12 +200,13 @@ async def logs_read(index: int, tail: int = 50):
 
 @router.get("/sysinfo")
 async def sysinfo_full():
-    return {"success": True, "data": sysinfo.get_sysinfo_text()}
+    text = await asyncio.to_thread(sysinfo.get_sysinfo_text)
+    return {"success": True, "data": text}
 
 
 @router.get("/sysinfo/cpu")
 async def sysinfo_cpu():
-    return sysinfo.get_cpu_usage()
+    return await asyncio.to_thread(sysinfo.get_cpu_usage)
 
 
 @router.get("/sysinfo/memory")

--- a/src/linux_server_bot/monitoring/checks/system.py
+++ b/src/linux_server_bot/monitoring/checks/system.py
@@ -6,6 +6,7 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
+from linux_server_bot.shared.cpu import read_cpu_percent
 from linux_server_bot.shared.shell import run_shell
 from linux_server_bot.shared.telegram import escape_html
 
@@ -17,61 +18,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _read_cpu_times() -> tuple[int, int] | None:
-    """Read aggregate CPU jiffies from /proc/stat. Returns (total, idle) or None.
-
-    Idle is just the ``idle`` column, matching ``top``'s ``id`` field
-    (``$8`` in the previous awk parse) -- iowait is NOT treated as idle, so
-    iowait-heavy workloads still count toward the alert threshold.
-    """
-    result = run_shell("head -n 1 /proc/stat")
-    if not result.success:
-        return None
-    parts = result.stdout.split()
-    if len(parts) < 5 or parts[0] != "cpu":
-        return None
-    try:
-        fields = [int(x) for x in parts[1:]]
-    except ValueError:
-        return None
-    idle = fields[3]
-    total = sum(fields)
-    return total, idle
-
-
-def _get_cpu_usage() -> float | None:
-    """Get total CPU usage percentage from /proc/stat over a 1-second window.
-
-    Replaces the previous ``top -bn 1 | awk`` parsing which mis-read idle as 0
-    whenever any %Cpu(s) field reached 100.0 (top's fixed-width column shifts
-    by one when the leading space disappears, so awk's $8 became "ni," instead
-    of the idle value).
-    """
-    first = _read_cpu_times()
-    if first is None:
-        logger.warning("Could not read /proc/stat (first sample)")
-        return None
-    time.sleep(1)
-    second = _read_cpu_times()
-    if second is None:
-        logger.warning("Could not read /proc/stat (second sample)")
-        return None
-    total_delta = second[0] - first[0]
-    idle_delta = second[1] - first[1]
-    if total_delta <= 0:
-        logger.warning(
-            "Invalid /proc/stat delta: total=%d idle=%d", total_delta, idle_delta
-        )
-        return None
-    return round(100.0 * (1.0 - idle_delta / total_delta), 1)
-
-
 def check_cpu(bot: telebot.TeleBot, config: AppConfig) -> None:
     """Check CPU usage with double-verification on high load."""
     from linux_server_bot.shared.telegram import send_to_all
 
     threshold = config.monitoring.thresholds.get("cpu_percent", 80)
-    usage = _get_cpu_usage()
+    usage = read_cpu_percent()
     if usage is None:
         return
 
@@ -81,7 +33,7 @@ def check_cpu(bot: telebot.TeleBot, config: AppConfig) -> None:
 
     delay = int(config.monitoring.thresholds.get("recheck_delay_seconds", 5))
     time.sleep(delay)
-    usage2 = _get_cpu_usage()
+    usage2 = read_cpu_percent()
     if usage2 is None or usage2 <= threshold:
         return
 

--- a/src/linux_server_bot/monitoring/checks/system.py
+++ b/src/linux_server_bot/monitoring/checks/system.py
@@ -32,11 +32,13 @@ def check_cpu(bot: telebot.TeleBot, config: AppConfig) -> None:
         return
 
     delay = int(config.monitoring.thresholds.get("recheck_delay_seconds", 5))
+    t0 = time.monotonic()
     time.sleep(delay)
     usage2 = read_cpu_percent()
     if usage2 is None or usage2 <= threshold:
         return
 
+    elapsed = int(time.monotonic() - t0 + 0.5)
     # Get top consumers
     top_result = run_shell("ps -eo pid,%cpu,%mem,comm --sort=-%cpu | head -n 11")
     consumers = escape_html(top_result.stdout)
@@ -45,7 +47,7 @@ def check_cpu(bot: telebot.TeleBot, config: AppConfig) -> None:
         bot,
         config,
         f"\U0001f525 CPU usage is high (>{threshold}%). "
-        f"First: {usage:.1f}%, after {delay}s: {usage2:.1f}%.\n"
+        f"First: {usage:.1f}%, after {elapsed}s: {usage2:.1f}%.\n"
         f"Top consumers:\n<pre>{consumers}</pre>",
         parse_mode="HTML",
     )

--- a/src/linux_server_bot/monitoring/checks/system.py
+++ b/src/linux_server_bot/monitoring/checks/system.py
@@ -17,14 +17,53 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _get_cpu_usage() -> float | None:
-    """Get total CPU usage percentage (100 - idle) from top."""
-    result = run_shell("top -bn 1 | awk '/^%Cpu/ {printf \"%.1f\", 100 - $8}'")
-    try:
-        return float(result.stdout.strip())
-    except (ValueError, IndexError):
-        logger.warning("Could not parse CPU usage: %s", result.stdout)
+def _read_cpu_times() -> tuple[int, int] | None:
+    """Read aggregate CPU jiffies from /proc/stat. Returns (total, idle) or None.
+
+    Idle is just the ``idle`` column, matching ``top``'s ``id`` field
+    (``$8`` in the previous awk parse) -- iowait is NOT treated as idle, so
+    iowait-heavy workloads still count toward the alert threshold.
+    """
+    result = run_shell("head -n 1 /proc/stat")
+    if not result.success:
         return None
+    parts = result.stdout.split()
+    if len(parts) < 5 or parts[0] != "cpu":
+        return None
+    try:
+        fields = [int(x) for x in parts[1:]]
+    except ValueError:
+        return None
+    idle = fields[3]
+    total = sum(fields)
+    return total, idle
+
+
+def _get_cpu_usage() -> float | None:
+    """Get total CPU usage percentage from /proc/stat over a 1-second window.
+
+    Replaces the previous ``top -bn 1 | awk`` parsing which mis-read idle as 0
+    whenever any %Cpu(s) field reached 100.0 (top's fixed-width column shifts
+    by one when the leading space disappears, so awk's $8 became "ni," instead
+    of the idle value).
+    """
+    first = _read_cpu_times()
+    if first is None:
+        logger.warning("Could not read /proc/stat (first sample)")
+        return None
+    time.sleep(1)
+    second = _read_cpu_times()
+    if second is None:
+        logger.warning("Could not read /proc/stat (second sample)")
+        return None
+    total_delta = second[0] - first[0]
+    idle_delta = second[1] - first[1]
+    if total_delta <= 0:
+        logger.warning(
+            "Invalid /proc/stat delta: total=%d idle=%d", total_delta, idle_delta
+        )
+        return None
+    return round(100.0 * (1.0 - idle_delta / total_delta), 1)
 
 
 def check_cpu(bot: telebot.TeleBot, config: AppConfig) -> None:

--- a/src/linux_server_bot/shared/actions/sysinfo.py
+++ b/src/linux_server_bot/shared/actions/sysinfo.py
@@ -10,19 +10,6 @@ from linux_server_bot.shared.shell import run_command, run_shell
 logger = logging.getLogger(__name__)
 
 _SYSINFO_SCRIPT = r"""
-# CPU (1s /proc/stat diff -- top's awk parsing breaks at 100% load)
-read _ u1 n1 s1 i1 w1 q1 sq1 st1 g1 gn1 < /proc/stat
-sleep 1
-read _ u2 n2 s2 i2 w2 q2 sq2 st2 g2 gn2 < /proc/stat
-total_diff=$(( (u2+n2+s2+i2+w2+q2+sq2+st2+g2+gn2) - (u1+n1+s1+i1+w1+q1+sq1+st1+g1+gn1) ))
-idle_diff=$(( i2 - i1 ))
-if [ "$total_diff" -gt 0 ]; then
-  cpu=$(awk -v t=$total_diff -v i=$idle_diff 'BEGIN { printf "%.1f", 100 * (1 - i/t) }')
-else
-  cpu="0.0"
-fi
-echo "CPU|${cpu}%"
-
 # Memory
 free -m | awk '/^Mem/ {printf "MEM|%dMB|%dMB|%dMB|%dMB\n", $2, $3, $4, $6}'
 
@@ -55,6 +42,7 @@ echo "HOST|$(hostname)"
 
 def get_sysinfo_text() -> str:
     """Get full system info as structured, formatted text."""
+    cpu_data = get_cpu_usage()
     result = run_shell(_SYSINFO_SCRIPT, timeout=30)
     if not result.stdout.strip():
         return result.stderr or "Could not retrieve system info."
@@ -77,8 +65,11 @@ def get_sysinfo_text() -> str:
     out.append(f"\U0001f5a5 {hostname}")
     out.append("")
 
-    # CPU
-    cpu = lines.get("CPU", "N/A")
+    # CPU — read via Python /proc/stat diff; shell-based diff is unreliable
+    # when _SYSINFO_SCRIPT runs through nsenter double-wrapping (sleep gets
+    # mangled, producing total_diff of 2-4 instead of ~400 jiffies).
+    cpu_pct = cpu_data.get("cpu_percent")
+    cpu = f"{cpu_pct}%" if cpu_pct is not None else "N/A"
     out.append(f"\U0001f4c8 CPU: {cpu}")
 
     # Memory

--- a/src/linux_server_bot/shared/actions/sysinfo.py
+++ b/src/linux_server_bot/shared/actions/sysinfo.py
@@ -3,14 +3,24 @@
 from __future__ import annotations
 
 import logging
+import time
 
 from linux_server_bot.shared.shell import run_command, run_shell
 
 logger = logging.getLogger(__name__)
 
 _SYSINFO_SCRIPT = r"""
-# CPU
-cpu=$(top -b -n 1 | awk '/^%Cpu/ {printf "%.1f", 100 - $8}')
+# CPU (1s /proc/stat diff -- top's awk parsing breaks at 100% load)
+read _ u1 n1 s1 i1 w1 q1 sq1 st1 g1 gn1 < /proc/stat
+sleep 1
+read _ u2 n2 s2 i2 w2 q2 sq2 st2 g2 gn2 < /proc/stat
+total_diff=$(( (u2+n2+s2+i2+w2+q2+sq2+st2+g2+gn2) - (u1+n1+s1+i1+w1+q1+sq1+st1+g1+gn1) ))
+idle_diff=$(( i2 - i1 ))
+if [ "$total_diff" -gt 0 ]; then
+  cpu=$(awk -v t=$total_diff -v i=$idle_diff 'BEGIN { printf "%.1f", 100 * (1 - i/t) }')
+else
+  cpu="0.0"
+fi
 echo "CPU|${cpu}%"
 
 # Memory
@@ -117,13 +127,43 @@ def get_sysinfo_text() -> str:
     return "\n".join(out)
 
 
-def get_cpu_usage() -> dict:
-    """Get CPU usage percentage."""
-    result = run_shell("top -bn 1 | awk '/^%Cpu/ {print 100 - $8}'")
+def _read_cpu_times() -> tuple[int, int] | None:
+    """Read aggregate CPU jiffies from /proc/stat. Returns (total, idle) or None."""
+    result = run_shell("head -n 1 /proc/stat")
+    if not result.success:
+        return None
+    parts = result.stdout.split()
+    if len(parts) < 5 or parts[0] != "cpu":
+        return None
     try:
-        return {"cpu_percent": float(result.stdout.strip()), "success": True}
-    except (ValueError, IndexError):
-        return {"cpu_percent": None, "success": False, "error": "Could not parse CPU usage"}
+        fields = [int(x) for x in parts[1:]]
+    except ValueError:
+        return None
+    idle = fields[3]
+    total = sum(fields)
+    return total, idle
+
+
+def get_cpu_usage() -> dict:
+    """Get CPU usage percentage from /proc/stat over a 1-second window.
+
+    Replaces the previous ``top -bn 1 | awk`` parsing which mis-read idle as 0
+    whenever any %Cpu(s) field reached 100.0 (top's fixed-width column shifts
+    by one when the leading space disappears, so awk's $8 became "ni," instead
+    of the idle value).
+    """
+    first = _read_cpu_times()
+    if first is None:
+        return {"cpu_percent": None, "success": False, "error": "Could not read /proc/stat"}
+    time.sleep(1)
+    second = _read_cpu_times()
+    if second is None:
+        return {"cpu_percent": None, "success": False, "error": "Could not read /proc/stat"}
+    total_delta = second[0] - first[0]
+    idle_delta = second[1] - first[1]
+    if total_delta <= 0:
+        return {"cpu_percent": None, "success": False, "error": "Invalid /proc/stat delta"}
+    return {"cpu_percent": round(100.0 * (1.0 - idle_delta / total_delta), 1), "success": True}
 
 
 def get_memory_usage() -> dict:

--- a/src/linux_server_bot/shared/actions/sysinfo.py
+++ b/src/linux_server_bot/shared/actions/sysinfo.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
-import time
 
+from linux_server_bot.shared.cpu import read_cpu_percent
 from linux_server_bot.shared.shell import run_command, run_shell
 
 logger = logging.getLogger(__name__)
@@ -118,43 +118,12 @@ def get_sysinfo_text() -> str:
     return "\n".join(out)
 
 
-def _read_cpu_times() -> tuple[int, int] | None:
-    """Read aggregate CPU jiffies from /proc/stat. Returns (total, idle) or None."""
-    result = run_shell("head -n 1 /proc/stat")
-    if not result.success:
-        return None
-    parts = result.stdout.split()
-    if len(parts) < 5 or parts[0] != "cpu":
-        return None
-    try:
-        fields = [int(x) for x in parts[1:]]
-    except ValueError:
-        return None
-    idle = fields[3]
-    total = sum(fields)
-    return total, idle
-
-
 def get_cpu_usage() -> dict:
-    """Get CPU usage percentage from /proc/stat over a 1-second window.
-
-    Replaces the previous ``top -bn 1 | awk`` parsing which mis-read idle as 0
-    whenever any %Cpu(s) field reached 100.0 (top's fixed-width column shifts
-    by one when the leading space disappears, so awk's $8 became "ni," instead
-    of the idle value).
-    """
-    first = _read_cpu_times()
-    if first is None:
+    """Get CPU usage percentage from /proc/stat over a 1-second window."""
+    pct = read_cpu_percent()
+    if pct is None:
         return {"cpu_percent": None, "success": False, "error": "Could not read /proc/stat"}
-    time.sleep(1)
-    second = _read_cpu_times()
-    if second is None:
-        return {"cpu_percent": None, "success": False, "error": "Could not read /proc/stat"}
-    total_delta = second[0] - first[0]
-    idle_delta = second[1] - first[1]
-    if total_delta <= 0:
-        return {"cpu_percent": None, "success": False, "error": "Invalid /proc/stat delta"}
-    return {"cpu_percent": round(100.0 * (1.0 - idle_delta / total_delta), 1), "success": True}
+    return {"cpu_percent": pct, "success": True}
 
 
 def get_memory_usage() -> dict:

--- a/src/linux_server_bot/shared/cpu.py
+++ b/src/linux_server_bot/shared/cpu.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import time
 
-from linux_server_bot.shared.shell import run_shell
+from linux_server_bot.shared.shell import run_command
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +16,7 @@ def _read_cpu_times() -> tuple[int, int] | None:
     Idle is just the ``idle`` column (index 3), not iowait, so iowait-heavy
     workloads still count toward usage/alert thresholds.
     """
-    result = run_shell("head -n 1 /proc/stat")
+    result = run_command(["head", "-n", "1", "/proc/stat"])
     if not result.success:
         return None
     parts = result.stdout.split()

--- a/src/linux_server_bot/shared/cpu.py
+++ b/src/linux_server_bot/shared/cpu.py
@@ -1,0 +1,50 @@
+"""Shared CPU usage helper used by both sysinfo actions and monitoring checks."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from linux_server_bot.shared.shell import run_shell
+
+logger = logging.getLogger(__name__)
+
+
+def _read_cpu_times() -> tuple[int, int] | None:
+    """Read aggregate CPU jiffies from /proc/stat. Returns (total, idle) or None.
+
+    Idle is just the ``idle`` column (index 3), not iowait, so iowait-heavy
+    workloads still count toward usage/alert thresholds.
+    """
+    result = run_shell("head -n 1 /proc/stat")
+    if not result.success:
+        return None
+    parts = result.stdout.split()
+    if len(parts) < 5 or parts[0] != "cpu":
+        return None
+    try:
+        fields = [int(x) for x in parts[1:]]
+    except ValueError:
+        return None
+    idle = fields[3]
+    total = sum(fields)
+    return total, idle
+
+
+def read_cpu_percent(sample_interval: float = 1.0) -> float | None:
+    """Return CPU usage % measured over *sample_interval* seconds, or None on error."""
+    first = _read_cpu_times()
+    if first is None:
+        logger.warning("Could not read /proc/stat (first sample)")
+        return None
+    time.sleep(sample_interval)
+    second = _read_cpu_times()
+    if second is None:
+        logger.warning("Could not read /proc/stat (second sample)")
+        return None
+    total_delta = second[0] - first[0]
+    idle_delta = second[1] - first[1]
+    if total_delta <= 0:
+        logger.warning("Invalid /proc/stat delta: total=%d idle=%d", total_delta, idle_delta)
+        return None
+    return round(100.0 * (1.0 - idle_delta / total_delta), 1)


### PR DESCRIPTION
PR #3 (bugfix/cpu-usage-alert) introduced a shell-based /proc/stat diff inside _SYSINFO_SCRIPT to replace the top|awk approach. This fixed monitoring/checks/system.py and get_cpu_usage() but the shell version in _SYSINFO_SCRIPT still produced quantized readings (50.0 %, 66.7 %, 75.0 %, 100.0 %) on RPi5.

Root cause: _SYSINFO_SCRIPT runs through run_shell() which wraps the entire script as nsenter -t 1 -m -- sh -c '<quoted>'. The outer sh -c layer processes the single-quoted string before nsenter forks its own sh -c, so 'sleep 1' between the two /proc/stat reads is swallowed or runs in a subshell that exits before sleep completes. Both reads land within a few milliseconds of each other, giving total_diff of 2-4 jiffies instead of ~400, hence the k/n fractions.

Fix: remove the CPU block from _SYSINFO_SCRIPT entirely and call the already-working Python get_cpu_usage() at the top of get_sysinfo_text().get_cpu_usage() uses two separate run_shell() calls with a Python time.sleep(1) between them -- Python controls the sleep, so it is immune to the double-wrapping issue.